### PR TITLE
ci: Add GitHub Pages based deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,82 @@
+name: MyST GitHub Pages Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+env:
+  # `BASE_URL` determines, relative to the root of the domain, the URL that your site is served from.
+  # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.
+  # If, instead, your site lives at the root of the domain, at `https://mydomain.org`, set `BASE_URL=''`.
+  BASE_URL: /${{ github.event.repository.name }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Pixi
+      uses: prefix-dev/setup-pixi@v0.8.8
+      with:
+        cache: true
+        cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+
+    - name: List installed packages
+      run: pixi list
+
+    - name: Build the site
+      run: pixi run build
+
+    - name: Upload site
+      uses: actions/upload-artifact@v4
+      with:
+        name: site
+        path: 'book/_build/html/'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+
+    steps:
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: site
+        path: 'deploy'
+
+    - name: Fix permissions
+      run: |
+        chmod -c -R +rX "deploy/" | while read line; do
+          echo "::warning title=Invalid file permissions automatically fixed::$line"
+        done
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: 'deploy'
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SciPy 2025 tutorial on [Reproducible Machine Learning Workflows for Scientists with Pixi](https://cfp.scipy.org/scipy2025/talk/GDN8PN/)
+# SciPy 2025 tutorial on [Reproducible Machine Learning Workflows for Scientists with Pixi](https://matthewfeickert-talks.github.io/reproducible-ml-for-scientists-with-pixi-scipy-2025/)
 
 ## Development
 

--- a/book/index.md
+++ b/book/index.md
@@ -12,7 +12,7 @@ The focus will be on applications using the PyTorch and JAX Python machine learn
 
 ## SciPy Logistical Information
 
-* Tutorial name: [Reproducible Machine Learning Workflows for Scientists with Pixi](https://cfp.scipy.org/scipy2025/talk/GDN8PN/)
+* Tutorial name: [Reproducible Machine Learning Workflows for Scientists with Pixi](https://matthewfeickert-talks.github.io/reproducible-ml-for-scientists-with-pixi-scipy-2025/)
 * Date: 2025-07-07
 * Time: 13:30 to 17:30
 * Location: Room 315

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,6 +5,10 @@ name = "reproducible-ml-for-scientists-with-pixi-scipy-2025"
 platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 version = "0.1.0"
 
+[tasks.build]
+description = "Build tutorial as static HTML website"
+cmd = "cd book && myst build --html"
+
 [tasks.start]
 cmd = "cd book && myst start"
 


### PR DESCRIPTION
* Add 'build' task to Pixi manifest tasks to build HTML static site.
* Add GitHub Actions based GitHub Pages deployment of site.