### PR TITLE
chore: Use correct company name of 'prefix.dev GmbH'

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -81,4 +81,4 @@ As Linux containers are their own technology that can be quite complex, all Linu
 
 ## Acknowledgments
 
-This tutorial was supported by the [US Research Software Sustainability Institute (URSSI)](https://urssi.us/) via grant [G-2022-19347](https://sloan.org/grant-detail/g-2022-19347) from the Sloan Foundation, [Prefix.dev](https://prefix.dev/), and [NVIDIA](https://www.nvidia.com/).
+This tutorial was supported by the [US Research Software Sustainability Institute (URSSI)](https://urssi.us/) via grant [G-2022-19347](https://sloan.org/grant-detail/g-2022-19347) from the Sloan Foundation, [prefix.dev GmbH](https://prefix.dev/), and [NVIDIA](https://www.nvidia.com/).

--- a/book/myst.yml
+++ b/book/myst.yml
@@ -24,7 +24,7 @@ project:
       id: ruben-arts
       affiliations:
         - id: prefix
-          institution: Prefix.dev
+          institution: prefix.dev GmbH
       github: ruben-arts
 
     - name: "John Kirkham"


### PR DESCRIPTION
* The legal name of [the company that creates Pixi](https://prefix.dev/) is 'prefix.dev GmbH', and so that should get used everywhere.