### PR TITLE
chore: Upgrade mystmd

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -30,7 +30,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.51.0-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/lychee-0.15.1-h53e704d_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.1-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nodejs-22.13.0-hf235a45_0.conda
@@ -67,7 +67,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/libuv-1.51.0-h4cb831e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/lychee-0.15.1-hf3953a5_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.1-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/nodejs-22.13.0-hffbc63d_0.conda
@@ -104,7 +104,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libuv-1.51.0-h5505292_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/lychee-0.15.1-hdf53557_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.1-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nodejs-22.13.0-h02a13b7_0.conda
@@ -138,7 +138,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.50.2-hf5d6505_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/lychee-0.15.1-hd533304_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.0-pyhe01879c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.1-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/nodejs-22.13.0-hfeaa22a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
@@ -762,16 +762,16 @@ packages:
   license: Apache-2.0 OR MIT
   size: 4854045
   timestamp: 1726763619951
-- conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.0-pyhe01879c_0.conda
-  sha256: d0c2e8413c4be9a38edd1b18b5adcd404442f9236e54e4a685c8aaa903f5f50c
-  md5: 8e18d9c5ef422b9be70cf59ad9346fc3
+- conda: https://prefix.dev/conda-forge/noarch/mystmd-1.5.1-pyhe01879c_0.conda
+  sha256: e41f786e21574dd21d98564fed210fb8b351de95254cd005d9d1fa1c88702fff
+  md5: f513ee75eee8143e300f42642292e447
   depends:
   - python >=3.9
   - nodejs >=18
   - python
   license: MIT
-  size: 2163869
-  timestamp: 1750800268155
+  size: 2163865
+  timestamp: 1751692750216
 - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
   sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
   md5: 47e340acb35de30501a76c7c799c41d7

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,6 +29,6 @@ cmd = "lychee --no-progress book/*.md"
 description = "Check links in the tutorial, might fail if no GITHUB_TOKEN is set"
 
 [dependencies]
-mystmd = ">=1.5.0,<2"
+mystmd = ">=1.5.1,<2"
 pre-commit = ">=4.2.0,<5"
 lychee = ">=0.15.1,<0.16"


### PR DESCRIPTION
* Upgrade mystmd to v1.5.1.
   - This redeploy will also pick up [`myst-theme` `v0.17.0`](https://github.com/jupyter-book/myst-theme/releases/tag/myst-to-react%400.17.0) with fix from @rowanc1.
   - c.f. https://github.com/jupyter-book/myst-theme/pull/627

N.B.: @jakirkham @ruben-arts for local builds, delete the `book/_build` directory and then run `pixi run start` again.