### PR TITLE
feat: Add CuPy and CuDF example

### DIFF
--- a/book/code/cudf-example/pixi.toml
+++ b/book/code/cudf-example/pixi.toml
@@ -13,3 +13,5 @@ cuda = "12"
 
 [target.linux-64.dependencies]
 cudf = ">=25.6.0,<26"
+requests = ">=2.32.4,<3"
+aiohttp = ">=3.12.13,<4"

--- a/book/code/cudf-example/pixi.toml
+++ b/book/code/cudf-example/pixi.toml
@@ -1,0 +1,15 @@
+[workspace]
+channels = ["rapidsai", "conda-forge"]
+name = "cudf-example"
+platforms = ["linux-64", "osx-arm64", "win-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+
+[system-requirements]
+cuda = "12"
+
+[target.linux-64.dependencies]
+cudf = ">=25.6.0,<26"

--- a/book/code/cupy-example.py
+++ b/book/code/cupy-example.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import cupy as cp
+
+# Array APIs are the same though operating on different hardware devices
+x_cpu = np.array([1, 2, 3])
+x_gpu = cp.array([1, 2, 3])
+
+l2_cpu = np.linalg.norm(x_cpu)
+l2_gpu = cp.linalg.norm(x_gpu)
+
+print(f"NumPy array {l2_cpu} on device: {x_cpu.device}")
+print(f"CuPy array {l2_gpu} on device: {x_gpu.device}")

--- a/book/cuda-hardware-acceleration.md
+++ b/book/cuda-hardware-acceleration.md
@@ -91,7 +91,7 @@ One of the libraries is [CuDF](https://docs.rapids.ai/api/cudf/stable/) &mdash; 
 
 ### Constructing the workspace
 
-CuDF is not available on conda-forge, but it is available on the Python Package Index (PyPI) as [`cudf-cu12`](https://pypi.org/project/cudf-cu12/) and on the [`rapidsai` conda channel on Anaconda.org](https://anaconda.org/rapidsai/cudf).
+CuDF is not available on conda-forge, but it is available on the Python Package Index (PyPI) as [`cudf-cu12`](https://pypi.org/project/cudf-cu12/) and on the [`rapidsai` conda channel on Anaconda.org as `cudf`](https://anaconda.org/rapidsai/cudf).
 We can install it through either method, but to keep working with conda package, we'll create a workspace that installs it from the `rapdsai` conda channel.
 
 :::: {tip} Construct the CuDF workspace
@@ -144,6 +144,8 @@ and you should now have the workspace.
 
 :::
 ::::
+
+For time today, we won't cover CuDF fully, but there are [user guides for how to use CuDF](https://github.com/NVIDIA/accelerated-computing-hub/blob/2186298825b85ef38f08e779af7992b8d762289f/gpu-python-tutorial/6.0_cuDF.ipynb), as seen below.
 
 ::: {important} Further references
 

--- a/book/cuda-hardware-acceleration.md
+++ b/book/cuda-hardware-acceleration.md
@@ -23,6 +23,7 @@ version = "0.1.0"
 [tasks]
 
 [dependencies]
+python = ">=3.13.5,<3.14"
 
 [system-requirements]
 cuda = "12"
@@ -51,6 +52,15 @@ and add the CUDA system requirements
 
 ```bash
 pixi workspace system-requirements add cuda 12
+```
+
+Then add Python as a common dependency to help ensure the latest Python is picked up
+
+```bash
+pixi add python
+```
+```
+✔ Added python >=3.13.5,<3.14
 ```
 
 and then add the CuPy dependencies for the target platform of `linux-64`.

--- a/book/cuda-hardware-acceleration.md
+++ b/book/cuda-hardware-acceleration.md
@@ -89,6 +89,62 @@ There are other CUDA accelerated libraries for scientific Python as well.
 NVIDIA has created the [RAPIDS](https://rapids.ai/) data science collection of libraries for running end-to-end data science pipelines fully on GPUs with CUDA.
 One of the libraries is [CuDF](https://docs.rapids.ai/api/cudf/stable/) &mdash; a high level Python library for manipulating DataFrames on the GPU with Pandas-like idioms.
 
+### Constructing the workspace
+
+CuDF is not available on conda-forge, but it is available on the Python Package Index (PyPI) as [`cudf-cu12`](https://pypi.org/project/cudf-cu12/) and on the [`rapidsai` conda channel on Anaconda.org](https://anaconda.org/rapidsai/cudf).
+We can install it through either method, but to keep working with conda package, we'll create a workspace that installs it from the `rapdsai` conda channel.
+
+:::: {tip} Construct the CuDF workspace
+
+```{literalinclude} code/cudf-example/pixi.toml
+```
+
+::: {hint} Walkthrough if needed
+:class: dropdown
+
+Initialize the workspace
+
+```bash
+pixi init ~/reproducible-ml-scipy-2025/cudf-example
+cd ~/reproducible-ml-scipy-2025/cudf-example
+```
+
+add all the platforms we'd like people to be able to develop for, even though this will be run on `linux-64`
+
+```bash
+pixi workspace platform add linux-64 osx-arm64 win-64
+```
+
+and add the CUDA system requirements
+
+```bash
+pixi workspace system-requirements add cuda 12
+```
+
+and then add the `rapidsai` conda channel but note that for things to work we need it to have **higher** priority than conda-forge
+
+```bash
+pixi workspace channel add --prepend rapidsai
+```
+```
+✔ Added rapidsai (https://conda.anaconda.org/rapidsai/)
+```
+
+Then add the CuDF dependencies for the target platform of `linux-64`.
+
+```bash
+pixi add --platform linux-64 cudf
+```
+```
+✔ Added cudf >=25.6.0,<26
+Added these only for platform(s): linux-64
+```
+
+and you should now have the workspace.
+
+:::
+::::
+
 ::: {important} Further references
 
 * The [NVIDIA Accelerated Computing Hub](https://github.com/NVIDIA/accelerated-computing-hub) is an open source GitHub repository that serves as a curated collection of educational resources related to general purpose GPU programming.

--- a/book/cuda-hardware-acceleration.md
+++ b/book/cuda-hardware-acceleration.md
@@ -1,0 +1,69 @@
+# General Hardware Acceleration with CUDA
+
+So far we've focused on machine learning examples, but CUDA hardware accelerated workflows extend far beyond AI/ML.
+
+## CuPy Example
+
+Perhaps one of the most well known CUDA accelerated array programming libraries in [CuPy](https://cupy.dev/), which is designed to have APIs that are highly compatible with NumPy and SciPy so that people can think in the common Scientific Python idioms while still leveraging CUDA.
+
+### Constructing the workspace
+
+CuPy is distributed on PyPI and on conda-forge, so we can create a Pixi workspace that supports its CUDA requirements and then adds CuPy as well.
+
+:::: {tip} Construct the CuPy workspace
+
+:::{code} toml
+:filename: pixi.toml
+[workspace]
+channels = ["conda-forge"]
+name = "cupy-example"
+platforms = ["linux-64", "osx-arm64", "win-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+
+[system-requirements]
+cuda = "12"
+
+[target.linux-64.dependencies]
+cupy = ">=13.4.1,<14"
+:::
+
+::: {hint} Walkthrough if needed
+:class: dropdown
+
+Initialize the workspace
+
+```bash
+pixi init ~/reproducible-ml-scipy-2025/cupy-example
+cd ~/reproducible-ml-scipy-2025/cupy-example
+```
+
+add all the platforms we'd like people to be able to develop for, even though this will be run on `linux-64`
+
+```bash
+pixi workspace platform add linux-64 osx-arm64 win-64
+```
+
+and add the CUDA system requirements
+
+```bash
+pixi workspace system-requirements add cuda 12
+```
+
+and then add the CuPy dependencies for the target platform of `linux-64`.
+
+```bash
+pixi add --platform linux-64 cupy
+```
+```
+✔ Added cupy >=13.4.1,<14
+Added these only for platform(s): linux-64
+```
+
+and you should now have the workspace.
+
+:::
+::::

--- a/book/cuda-hardware-acceleration.md
+++ b/book/cuda-hardware-acceleration.md
@@ -130,13 +130,15 @@ pixi workspace channel add --prepend rapidsai
 ✔ Added rapidsai (https://conda.anaconda.org/rapidsai/)
 ```
 
-Then add the CuDF dependencies for the target platform of `linux-64`.
+Then add the CuDF dependencies for the target platform of `linux-64` (`requests` and `aiohttp` are for an example).
 
 ```bash
-pixi add --platform linux-64 cudf
+pixi add --platform linux-64 cudf requests aiohttp
 ```
 ```
 ✔ Added cudf >=25.6.0,<26
+✔ Added requests >=2.32.4,<3
+✔ Added aiohttp >=3.12.13,<4
 Added these only for platform(s): linux-64
 ```
 

--- a/book/cuda-hardware-acceleration.md
+++ b/book/cuda-hardware-acceleration.md
@@ -72,23 +72,8 @@ and you should now have the workspace.
 
 which gives us access to CuPy's hardware acceleration, as shown in this [example from the CuPy documentation](https://docs.cupy.dev/en/stable/user_guide/basic.html)
 
-:::{code} python
-:filename: cupy-example.py
-#!/usr/bin/env python3
-
-import numpy as np
-import cupy as cp
-
-# Array APIs are the same though operating on different hardware devices
-x_cpu = np.array([1, 2, 3])
-x_gpu = cp.array([1, 2, 3])
-
-l2_cpu = np.linalg.norm(x_cpu)
-l2_gpu = cp.linalg.norm(x_gpu)
-
-print(f"NumPy array {l2_cpu} on device: {x_cpu.device}")
-print(f"CuPy array {l2_gpu} on device: {x_gpu.device}")
-:::
+```{literalinclude} code/cupy-example.py
+```
 
 ```bash
 pixi run python cupy-example.py
@@ -97,3 +82,18 @@ pixi run python cupy-example.py
 NumPy array 3.7416573867739413 on device: cpu
 CuPy array 3.7416573867739413 on device: <CUDA Device 0>
 ```
+
+## CuDF Example
+
+There are other CUDA accelerated libraries for scientific Python as well.
+NVIDIA has created the [RAPIDS](https://rapids.ai/) data science collection of libraries for running end-to-end data science pipelines fully on GPUs with CUDA.
+One of the libraries is [CuDF](https://docs.rapids.ai/api/cudf/stable/) &mdash; a high level Python library for manipulating DataFrames on the GPU with Pandas-like idioms.
+
+::: {important} Further references
+
+* The [NVIDIA Accelerated Computing Hub](https://github.com/NVIDIA/accelerated-computing-hub) is an open source GitHub repository that serves as a curated collection of educational resources related to general purpose GPU programming.
+It contains many excellent examples.
+* In the tutorials session before this one (morning of 2025-07-07), [Katrina Riehl](https://github.com/nv-kriehl) taught [The Accelerated Python Developer's Toolbox](https://cfp.scipy.org/scipy2025/talk/KA7ZYR/) which covers CUDA and Python in-depth.
+* In the tutorials session before this one (morning of 2025-07-07), Allison Ding taught [Scaling Clustering for Big Data: Leveraging RAPIDS cuML](https://cfp.scipy.org/scipy2025/talk/WSSAU7/) which covers the cuML RAPIDS library.
+
+:::

--- a/book/cuda-hardware-acceleration.md
+++ b/book/cuda-hardware-acceleration.md
@@ -23,12 +23,12 @@ version = "0.1.0"
 [tasks]
 
 [dependencies]
-python = ">=3.13.5,<3.14"
 
 [system-requirements]
 cuda = "12"
 
 [target.linux-64.dependencies]
+python = ">=3.13.5,<3.14"
 cupy = ">=13.4.1,<14"
 :::
 
@@ -54,21 +54,13 @@ and add the CUDA system requirements
 pixi workspace system-requirements add cuda 12
 ```
 
-Then add Python as a common dependency to help ensure the latest Python is picked up
+Then add the CuPy dependencies for the target platform of `linux-64`.
 
 ```bash
-pixi add python
+pixi add --platform linux-64 python cupy
 ```
 ```
 ✔ Added python >=3.13.5,<3.14
-```
-
-and then add the CuPy dependencies for the target platform of `linux-64`.
-
-```bash
-pixi add --platform linux-64 cupy
-```
-```
 ✔ Added cupy >=13.4.1,<14
 Added these only for platform(s): linux-64
 ```
@@ -77,3 +69,31 @@ and you should now have the workspace.
 
 :::
 ::::
+
+which gives us access to CuPy's hardware acceleration, as shown in this [example from the CuPy documentation](https://docs.cupy.dev/en/stable/user_guide/basic.html)
+
+:::{code} python
+:filename: cupy-example.py
+#!/usr/bin/env python3
+
+import numpy as np
+import cupy as cp
+
+# Array APIs are the same though operating on different hardware devices
+x_cpu = np.array([1, 2, 3])
+x_gpu = cp.array([1, 2, 3])
+
+l2_cpu = np.linalg.norm(x_cpu)
+l2_gpu = cp.linalg.norm(x_gpu)
+
+print(f"NumPy array {l2_cpu} on device: {x_cpu.device}")
+print(f"CuPy array {l2_gpu} on device: {x_gpu.device}")
+:::
+
+```bash
+pixi run python cupy-example.py
+```
+```
+NumPy array 3.7416573867739413 on device: cpu
+CuPy array 3.7416573867739413 on device: <CUDA Device 0>
+```

--- a/book/myst.yml
+++ b/book/myst.yml
@@ -36,7 +36,7 @@ project:
   github: https://github.com/matthewfeickert-talks/reproducible-ml-for-scientists-with-pixi-scipy-2025
   abbreviations:
     CLI : "Command Line Interface"
-    TOML: "Tom’s Obvious, Minimal Language"
+    TOML: "Tom's Obvious, Minimal Language"
     CUDA: "Compute Unified Device Architecture"
     GPU: "Graphical Processing Unit"
     CPU: "Central Processing Unit"
@@ -52,6 +52,7 @@ project:
     - file: pixi-exercise.md
     - file: cuda-conda.md
     - file: ml-example.md
+    - file: cuda-hardware-acceleration.md
     - file: containers.md
     # appendix
     - file: glossary.md


### PR DESCRIPTION
Addresses parts of #20 

* Add 'General Hardware Acceleration with CUDA' section.
* Add CuPy CUDA example.
* Add CuDF CUDA example.
* Add Pixi manifest files for the example workspaces.
* Add references for further information on CUDA accelerated tooling.