### PR TITLE
chore: Revise platforms for restrictions

### DIFF
--- a/book/code/cudf-example/pixi.toml
+++ b/book/code/cudf-example/pixi.toml
@@ -1,12 +1,15 @@
 [workspace]
 channels = ["rapidsai", "conda-forge"]
 name = "cudf-example"
-platforms = ["linux-64", "osx-arm64", "win-64"]
+platforms = ["linux-64"]
 version = "0.1.0"
 
 [tasks]
 
 [dependencies]
+cudf = ">=25.6.0,<26"
+requests = ">=2.32.4,<3"
+aiohttp = ">=3.12.13,<4"
 
 [system-requirements]
 cuda = "12"

--- a/book/code/cupy-example/pixi.toml
+++ b/book/code/cupy-example/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 channels = ["conda-forge"]
 name = "cupy-example"
-platforms = ["linux-64", "osx-arm64", "win-64"]
+platforms = ["linux-64", "win-64"]
 version = "0.1.0"
 
 [tasks]

--- a/book/cuda-hardware-acceleration.md
+++ b/book/cuda-hardware-acceleration.md
@@ -28,7 +28,7 @@ cd ~/reproducible-ml-scipy-2025/cupy-example
 add all the platforms we'd like people to be able to develop for, even though this will be run on `linux-64`
 
 ```bash
-pixi workspace platform add linux-64 osx-arm64 win-64
+pixi workspace platform add linux-64 win-64
 ```
 
 and add the CUDA system requirements
@@ -92,10 +92,10 @@ pixi init ~/reproducible-ml-scipy-2025/cudf-example
 cd ~/reproducible-ml-scipy-2025/cudf-example
 ```
 
-add all the platforms we'd like people to be able to develop for, even though this will be run on `linux-64`
+As CuDF is available as a conda package only for `linux-64` we'll just set that as the platform
 
 ```bash
-pixi workspace platform add linux-64 osx-arm64 win-64
+pixi workspace platform add linux-64
 ```
 
 and add the CUDA system requirements


### PR DESCRIPTION
* Remove osx-arm64 from cupy as people will be on linux-64 and cupy requires CUDA.
* Remove osx-arm64 and win-64 for cudf as the cudf conda package is linux-64 only.