### PR TITLE
Fix typo in machine learning example

### DIFF
--- a/book/ml-example.md
+++ b/book/ml-example.md
@@ -87,7 +87,7 @@ pixi workspace environment add --feature cpu cpu
 ✔ Added environment cpu
 ```
 
-and insatiate it with particular versions
+and instantiate it with particular versions
 
 ```bash
 pixi upgrade --feature cpu


### PR DESCRIPTION
This PR fixes a typo that I ran into at the ml-example of this tutorial.