### PR TITLE
fix: Update and correct broken links

### DIFF
--- a/book/containers.md
+++ b/book/containers.md
@@ -376,6 +376,6 @@ Let's step through the `docker run` command to understand what's happening.
 
 For today we're focusing on Docker containers, but if you run your workflows at High-Throughput Computing (HTC) or High-Performance Computing (HPC) centers with orchestration systems like HTCondor or SLURM you will probably be restricted to using a different Linux container system called Apptainer.
 
-The [Reproducible Machine Learning Workflows for Scientists](https://carpentries-incubator.github.io/reproducible-ml-workflows/) Carpentries Incubator lesson has [further information and examples for using Apptainer with these workflows](https://carpentries-incubator.github.io/reproducible-ml-workflows/pixi_deployment.html).
+The [Reproducible Machine Learning Workflows for Scientists](https://carpentries-incubator.github.io/reproducible-ml-workflows/) Carpentries Incubator lesson has [further information and examples for using Apptainer with these workflows](https://carpentries-incubator.github.io/reproducible-ml-workflows/pixi-deployment.html).
 
 :::

--- a/book/cuda-conda.md
+++ b/book/cuda-conda.md
@@ -16,7 +16,7 @@ CUDA software environments were bespoke and not many scientists understood how t
 
 ### Initial implementation
 
-After discussion in [late 2018](https://github.com/conda-forge/conda-forge.github.io/issues/687) to better support the scientific developer community, the CUDA packaging community agreed to use the [Anaconda `defaults` channel](https://www.anaconda.com/docs/tools/working-with-conda/reference/default-channels)'s `cudatoolkit` package.
+After discussion in [late 2018](https://github.com/conda-forge/conda-forge.github.io/issues/687) to better support the scientific developer community, the CUDA packaging community agreed to use the [Anaconda `defaults` channel](https://www.anaconda.com/docs/getting-started/working-with-conda/reference/default-channels)'s `cudatoolkit` package.
 Initially the `cudatoolkit` package was designed around [Numba's CUDA needs](https://github.com/numba/conda-recipe-cudatoolkit), though it evolved to a bundle of redistributable CUDA libraries.
 In 2019, NVIDIA began packaging the `cudatoolkit` package in the [`nvidia` conda channel](https://anaconda.org/nvidia).
 With help from the broader community, the `cudatoolkit` package was added to [`conda-forge` in 2020](https://github.com/conda-forge/staged-recipes/pull/12882).


### PR DESCRIPTION
* Update links that have moved since the tutorial was created and are now broken given insufficient redirect.